### PR TITLE
Deep cell extra params

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     numpy~=1.23
     cellpose==1.0.1
     pandas==1.4.1
-    scipy==1.8.0
+    scipy==1.9.3
     scikit-image==0.19.2
     matplotlib==3.5.1
 	PyYAML==6.0

--- a/src/polarityjam/segmentation/deepcell.py
+++ b/src/polarityjam/segmentation/deepcell.py
@@ -31,104 +31,114 @@ def setup_album():
 
 
 def run():
-    """Python code that is executed in the solution environment."""
     # parse arguments
     args = get_args()
 
-    # imports
+    # imports 
     import argparse
-    from pathlib import Path
-
     import numpy as np
     import tifffile
-    from deepcell.applications import Mesmer
     from skimage.io import imread
+    from pathlib import Path
+    from deepcell.applications import Mesmer
 
-    def segmentation(
-        args: argparse.Namespace, image_nuclear: str, image_membrane: str
-    ) -> str:
-        """Load the color channels, prepares them for the network and runs the segmentation.
+    def segmentation(args: argparse.Namespace, image_nuclear: str, image_membrane: str = None) -> str:
+        """Loads the color channels, prepares them for the network, and runs the segmentation.
 
         Args:
             args: Arguments provided by the user.
             image_nuclear: Name of the image containing the nuclei.
-            image_membrane: Name of the image containing the membrane.
+            image_membrane: Name of the image containing the membrane (optional).
 
         Returns:
             Name of the processed image.
         """
-        image_nuc = imread(Path(args.folder_path) / image_nuclear)
-        image_mem = imread(Path(args.folder_path) / image_membrane)
-        if len(image_nuc.shape) > 2:
-            image_nuc = image_nuc[:, :, args.channel_nuclear]
-        if len(image_mem.shape) > 2:
-            image_mem = image_mem[:, :, args.channel_membrane]
-        # if its only one channel (H and W), add a channel dimension
-        if len(image_nuc.shape) == 2:
+        image_nuc = imread(Path(args.input_path) / image_nuclear)
+
+        if (len(image_nuc.shape) > 2):
+            image_nuc = image_nuc[:,:,args.channel_nuclear]
+        if (len(image_nuc.shape) == 2):
             image_nuc = np.expand_dims(image_nuc, axis=-1)
-        if len(image_mem.shape) == 2:
-            image_mem = np.expand_dims(image_mem, axis=-1)
 
-        # combine and expand to [1, H, W, C]
+        if image_membrane:
+            image_mem = imread(Path(args.input_path) / image_membrane)
+            if (len(image_mem.shape) > 2):
+                image_mem = image_mem[:,:,args.channel_membrane]
+            if (len(image_mem.shape) == 2):
+                # Expand from [H, W] to [H, W, C]
+                image_mem = np.expand_dims(image_mem, axis=-1)
+        else:
+            # Create an empty channel for membrane if it's not provided
+            image_mem = np.zeros_like(image_nuc)
+            args.segmentation_mode = "nuclear"
+
+        # Combine and expand to [1, H, W, C]
         image_prepped = np.concatenate([image_nuc, image_mem], axis=-1)
-        image_prepped = np.expand_dims(image_prepped, 0)
+        image_prepped = np.expand_dims(image_prepped,0) 
 
-        # model loading
+        # Model loading
         # see https://github.com/vanvalenlab/deepcell-tf/blob/master/deepcell/applications/mesmer.py
         app = Mesmer()
-        print(
-            "Image resolution the network was trained on:",
-            app.model_mpp,
-            "microns per pixel",
-        )
+        print('Image resolution the network was trained on:', app.model_mpp, 'microns per pixel')
 
-        # prediction
+        # Postprocessing
+        if (args.maxima_threshold is None) or (args.maxima_threshold <= 0):
+            if args.segmentation_mode == "whole-cell":
+                args.maxima_threshold = 0.1
+            elif args.segmentation_mode == "nuclear":
+                args.maxima_threshold = 0.075
+
+        postprocess = {
+            "maxima_threshold": args.maxima_threshold,
+            "maxima_smooth": args.maxima_smooth,
+            "interior_threshold": args.interior_threshold,
+            "interior_smooth": args.interior_smooth,
+            "small_objects_threshold": args.small_objects_threshold,
+            "fill_holes_threshold": args.fill_holes_threshold,
+            "radius": args.radius,
+            "pixel_expansion": args.pixel_expansion
+        }
+
+        # Prediction
         segmentation_predictions = app.predict(
             image_prepped,
             image_mpp=args.image_mpp,
+            postprocess_kwargs_whole_cell=postprocess,
+            postprocess_kwargs_nuclear=postprocess,
             compartment=args.segmentation_mode,
-            batch_size=1,
+            batch_size=1
         )
         segmentation_predictions = np.squeeze(segmentation_predictions)
-        # convert from 64 to 16 bit
+        # Convert from 64 to 16 bit
         segmentation_predictions = segmentation_predictions.astype(np.uint16)
 
-        # save the segmentation predictions
+        # Save the segmentation predictions
         image_name = Path(image_nuclear).stem
         output_name = Path(args.output_path) / (image_name + "_segmentation")
         Path(args.output_path).mkdir(parents=True, exist_ok=True)
         if args.save_mask:
             tifffile.imwrite(output_name.with_suffix(".tiff"), segmentation_predictions)
         if args.save_npy:
-            np.save(str(output_name) + ".npy", segmentation_predictions)
-        return str(output_name)
+            np.save(output_name, segmentation_predictions)
+        return output_name
 
-    # test if folder_path contains tif files
-    folder_path = Path(args.folder_path)
-    if folder_path.is_dir():
-        # get all files in folder
-        files = folder_path.glob("*.tif*")
-        if not files:
-            raise ValueError("No tif files found in folder.")
-    else:
+    # Test if input_path contains tif files
+    input_path = Path(args.input_path)
+    if not input_path.is_dir():
         raise ValueError("The provided folder path is not a folder.")
 
-    output_name = None
-    # run on one sample or whole folder
-    if args.image_nuclear and args.image_membrane:
-        output_name = segmentation(args, args.image_nuclear, args.image_membrane)
+    # Run on one sample or whole folder
+    if args.img_name_nuclear:
+        output_name = segmentation(args, args.img_name_nuclear, args.img_name_membrane)
     else:
+        files = list(input_path.glob('*.tif*'))
+        if not files:
+            raise ValueError("No tif files found in folder.")
         for file in files:
             output_name = segmentation(args, file, file)
 
-    if not output_name:
-        raise ValueError(
-            "Nothing done! No input provided (%s, %s)."
-            % (args.image_nuclear, args.image_membrane)
-        )
-
-    print("Segmentation saved to:", str(Path(output_name).resolve()))
-
+    print("Recent segmentation saved to:", output_name.resolve())
+    return
 
 setup(
     group="polarityjam",
@@ -140,85 +150,138 @@ setup(
     tags=["segmentation", "machine_learning", "images", "deepcell", "mesmer", "2D"],
     license="Modified Apache v2",
     documentation=["https://deepcell.readthedocs.io/en/master/"],
+    cite=[{
+        "text": "Noah F. Greenwald and Geneva Miller and Erick Moen and Alex Kong and Adam Kagel and Thomas Dougherty and Christine Camacho Fullaway and Brianna J. McIntosh and Ke Xuan Leow and Morgan Sarah Schwartz and Cole Pavelchek and Sunny Cui and Isabella Camplisson and Omer Bar-Tal and Jaiveer Singh and Mara Fong and Gautam Chaudhry and Zion Abraham and Jackson Moseley and Shiri Warshawsky and Erin Soon and Shirley Greenbaum and Tyler Risom and Travis Hollmann and Sean C. Bendall and Leeat Keren and William Graf and Michael Angelo and David Van Valen; Whole-cell segmentation of tissue images with human-level performance using large-scale data annotation and deep learning",
+        "doi": "https://doi.org/10.1038/s41587-021-01094-0"
+    }],
     covers=[],
     album_api_version="0.5.5",
     args=[
         {
-            "name": "image_nuclear",
+            "name": "input_path",
+            "type": "string",
+            "required": True,
+            "description": "Full path to the folder containing the images.",
+            "default": "./"
+        },
+        {
+            "name": "img_name_nuclear",
             "type": "string",
             "required": False,
-            "description": "Name of image containing the nuclei.",
-            "default": "",
+            "description": "Name of image containing the nuclei. (If not set or empty, the solution will run on all images in the folder while assuming each image contains nuclei and membrane information in the provided color channels.)",
+            "default": ""
         },
         {
             "name": "channel_nuclear",
             "type": "integer",
             "required": True,
             "description": "Channel index of the nuclear image, starting with 0.",
-            "default": 0,
+            "default": 0
         },
         {
-            "name": "image_membrane",
+            "name": "img_name_membrane",
             "type": "string",
             "required": False,
-            "description": "Name of the image containing the membrane."
-            " This can be the same file as the nuclear image,"
-            " but would require to set `channel_membrane` to a different value.",
-            "default": "",
+            "description": "Name of the image containing the membrane information. This can be in the same file as the nuclear image, but would require to set `channel_membrane` to a different value. If not set, an empty channel will be used for the membrane.",
+            "default": ""
         },
         {
             "name": "channel_membrane",
             "type": "integer",
-            "required": True,
-            "description": "Channel index of the membrane image, starting with 0.",
-            "default": 0,
+            "required": False,
+            "description": "Channel index of the membrane image, starting with 0. If `img_name_membrane` is not set, this value will be ignored.",
+            "default": 1
         },
         {
             "name": "image_mpp",
             "type": "float",
             "required": False,
-            "description": "Resolution of the image in `Microns per pixel`."
-            " If not provided, the resolution of the model will be used.",
-            "default": 0.5,
+            "description": "Resolution of the images in `Microns per pixel`. If not set, it will default to 0.5.",
+            "default": 0.5
         },
         {
             "name": "segmentation_mode",
             "type": "string",
             "required": False,
-            "description": "Segmentation mode can be either `whole-cell` or `nuclear`.",
-            "default": "whole-cell",
+            "description": "Segmentation mode can be either `whole-cell` or `nuclear`. If `img_name_membrane` is not set, this will default to `nuclear`.",
+            "default": "whole-cell"
         },
         {
             "name": "output_path",
             "type": "string",
             "required": False,
             "description": "Full path to the output folder in which the result gets stored.",
-            "default": "./output",
+            "default": "./output"
         },
         {
             "name": "save_mask",
             "type": "boolean",
             "required": False,
             "description": "Set this to `True` to save the segmentation mask as a tif file.",
-            "default": True,
+            "default": True
         },
         {
             "name": "save_npy",
             "type": "boolean",
             "required": False,
             "description": "Set this to `True` to save the segmentation mask as a numpy file.",
-            "default": False,
+            "default": False
         },
         {
-            "name": "folder_path",
-            "type": "string",
-            "required": True,
-            "description": "Full path to the folder containing the images."
-            " If provided without the names of the images, the solution will run on all images in "
-            "the folder while assuming each image contains nuclei and membrane"
-            " information in the provided color channels.",
-            "default": "./",
+            "name": "maxima_threshold",
+            "type": "float",
+            "required": False,
+            "description": "To finetune specific and consistent errors in your data, the following arguments can be used during postprocessing. Lower values will result in more cells being detected. Higher values will result in fewer cells being detected. When set to -1, the default for mode `whole_cell` (0.1) and for `nuclear` (0.075) will be applied",
         },
+        {
+            "name": "maxima_smooth",
+            "type": "float",
+            "required": False,
+            "description": "Default: 0",
+            "default": 0.0
+        },
+        {
+            "name": "interior_threshold",
+            "type": "float",
+            "required": False,
+            "description": "Comparison threshold for cell vs. background. Lower values tend to result in larger cells. Default: 0.2",
+            "default": 0.2
+        },
+        {
+            "name": "interior_smooth",
+            "type": "float",
+            "required": False,
+            "description": "Default: 0",
+            "default": 0.0
+        },
+        {
+            "name": "small_objects_threshold",
+            "type": "float",
+            "required": False,
+            "description": "Default: 15",
+            "default": 15.
+        },
+        {
+            "name": "fill_holes_threshold",
+            "type": "float",
+            "required": False,
+            "description": "Default: 15",
+            "default": 15.
+        },
+        {
+            "name": "radius",
+            "type": "float",
+            "required": False,
+            "description": ". Default: 2",
+            "default": 2.
+        }, 
+        {
+            "name": "pixel_expansion",
+            "type": "integer",
+            "required": False,
+            "description": "Add a manual pixel expansion after segmentation to each cell. Default: 0",
+            "default": 0
+        }
     ],
     run=run,
     dependencies={"environment_file": env_file},
@@ -315,7 +378,15 @@ class DeepCellSegmenter:
             "--save_mask=%s" % self.params.save_mask,
             "--image_mpp=%s" % self.mpp,
             "--output_path=%s" % self.tmp_dir.name,
-            "--folder_path=%s" % self.tmp_dir.name,
+            "--input_path=%s" % self.tmp_dir.name,
+            "--maxima_threshold=%s" % self.params.maxima_threshold,
+            "--maxima_smooth=%s" % self.params.maxima_smooth,
+            "--interior_threshold=%s" % self.params.interior_threshold,
+            "--interior_smooth=%s" % self.params.interior_smooth,
+            "--small_objects_threshold=%s" % self.params.small_objects_threshold,
+            "--fill_holes_threshold=%s" % self.params.fill_holes_threshold,
+            "--radius=%s" % self.params.radius,
+            "--pixel_expansion=%s" % self.params.pixel_expansion,
         ]
 
         # call solution

--- a/src/polarityjam/segmentation/deepcell.yml
+++ b/src/polarityjam/segmentation/deepcell.yml
@@ -1,3 +1,11 @@
 path: deepcell.DeepCellSegmenter
 segmentation_mode: whole-cell # whole-cell or nuclear
 save_mask: False
+maxima_threshold: 0.18 # -1 for default values depending on segmentation_mode
+maxima_smooth: 0.1
+interior_threshold: 0.1
+interior_smooth: 0.2
+small_objects_threshold: 25.
+fill_holes_threshold: 5.
+radius: 20.
+pixel_expansion: 0

--- a/src/polarityjam/segmentation/microsam.py
+++ b/src/polarityjam/segmentation/microsam.py
@@ -5,10 +5,15 @@ from album.runner.api import get_args, get_cache_path, setup
 
 env_file = """name:  microSAM
 channels:
+  - pytorch
+  - nvidia
   - conda-forge
 dependencies:
   - python=3.10
   - tifffile>=2023.7.18
+  - pytorch>=2.0.0
+  - torchvision>=0.15.0
+  - pytorch-cuda=11.7
   - micro_sam=0.3.0post1
   - pip
 """


### PR DESCRIPTION
Added the postprocessing parameters for the DeepCell model Mesmer. 
They can be configured to tackle consistent segmentation errors and e.g. expand the cell segmentations by a few pixels and apply different thresholds. 

Additionally, the dependencies for microSAM are now more detailed. 
The correct SciPy version for polarityjam got specified as well.

NOTE: tested on Windows 10. 