### PR TITLE
fix faulty polygon sorting

### DIFF
--- a/src/polarityjam/compute/compute.py
+++ b/src/polarityjam/compute/compute.py
@@ -37,13 +37,13 @@ def compute_reference_target_orientation_rad(
 def compute_ref_x_abs_angle_deg(
     ref_x: float, ref_y: float, x: float, y: float
 ) -> float:
-    """Compute the angle between the x-axis and the vector (x,y).
+    """Compute the angle between a reference point on the x-axis and another point (x,y).
 
     Args:
-        ref_y:
-            The y coordinate of the reference point
         ref_x:
             The x coordinate of the reference point
+        ref_y:
+            The y coordinate of the reference point
         x:
             The x coordinate
         y:

--- a/src/polarityjam/controller/plotter.py
+++ b/src/polarityjam/controller/plotter.py
@@ -2261,6 +2261,32 @@ class Plotter:
                     single_cell.cytosol_mask
                 )
 
+            if self.params.plot_sc_partitions:
+                half_masks = single_cell.half_mask(
+                    collection.get_runtime_params_by_img_name(img_name).cue_direction
+                )
+                quad_masks = single_cell.quarter_mask(
+                    collection.get_runtime_params_by_img_name(img_name).cue_direction
+                )
+                centered_masks["centered_half_mask_r"] = single_cell.center_mask(
+                    half_masks[0]
+                )
+                centered_masks["centered_half_mask_l"] = single_cell.center_mask(
+                    half_masks[1]
+                )
+                centered_masks["quadrant_mask_r"] = single_cell.center_mask(
+                    quad_masks[0]
+                )
+                centered_masks["quadrant_mask_t"] = single_cell.center_mask(
+                    quad_masks[1]
+                )
+                centered_masks["quadrant_mask_l"] = single_cell.center_mask(
+                    quad_masks[2]
+                )
+                centered_masks["quadrant_mask_b"] = single_cell.center_mask(
+                    quad_masks[3]
+                )
+
             # plot
             fig, ax = self._get_figure(len(centered_masks))
 

--- a/src/polarityjam/model/parameter.py
+++ b/src/polarityjam/model/parameter.py
@@ -195,6 +195,7 @@ class PlotParameter(Parameter):
         self.plot_shape_orientation = None
         self.plot_foi = None
         self.plot_sc_image = None
+        self.plot_sc_partitions = None
 
         self.outline_width = None
         self.show_polarity_angles = None

--- a/src/polarityjam/utils/resources/parameters.yml
+++ b/src/polarityjam/utils/resources/parameters.yml
@@ -40,6 +40,7 @@ plot_ratio_method: True
 plot_shape_orientation: True
 plot_foi: True
 plot_sc_image: False
+plot_sc_partitions: False
 show_statistics: False
 show_polarity_angles: True
 show_graphics_axis: False


### PR DESCRIPTION
when splitting cells in two halfs (along a given cue direction) the sorting of the two corresponding polygons was in some cases faulty. Hence, in some cases that lead to a faulty value of the cue_directional_intensity_ratio. 

This fix corrects the sorting algorithmus.