### PR TITLE
64 mandatory junction channel

### DIFF
--- a/album_solutions/solution.py
+++ b/album_solutions/solution.py
@@ -102,7 +102,7 @@ setup(
     description="A Solution to run the polarityjam Feature Extraction Pipeline.",
     solution_creators=["Lucas Rieckert", "Jan Philipp Albrecht"],
     tags=["polarityjam", "test"],
-    license="UNLICENSE",
+    license="MIT",
     documentation=["doc.md"],
     covers=[{"description": "Polarityjam cover image", "source": "cover.png"}],
     album_api_version="0.5.5",

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# Polarityjam Documentation
+Short description of how to locally look at the documentation after you jave done some changes. 
+Especially those that refer to the notebooks.
+
+
+## Build and check the documentation
+1. install conda
+2. install an environment:
+```
+conda create -n sphinx-polarityjam python pip
+conda activate sphinx-polarityjam
+pip install -r docs/requirements.txt
+```
+3. make sure "pandoc" is isntalled (on ubuntu: `sudo apt install pandoc`)
+4. go to docs folder: `cd docs/`
+5. build the documentation locally with `make html`. A folder "_build" should appear (e.g. docs/_build). 
+This is your local version of the documentation!
+6. check for errors in the make process - resolve eventual errors
+7. open your browser and drag and drop docs/_build/html/index.html into your window.
+This will be the view users have on readthedocs.org once you push changes to the docs branch
+8. check documentation locally for errors and style. Especially the notebook files! Repeat step 5-8 until satisfied.
+9. DO NOT ADD AND THEN PUSH THE "_build" DIRECTORY! IT SHOULD NOT BE IN THE GITHUB REPOSITORY OF POLARITYJAM!
+
+
+
+

--- a/src/polarityjam/segmentation/cellpose.py
+++ b/src/polarityjam/segmentation/cellpose.py
@@ -111,21 +111,43 @@ class CellposeSegmenter(Segmenter):
         im_junction = None
         im_nucleus = None
 
-        if img_parameter.channel_junction >= 0:
-            get_logger().info(
-                "Junction channel used for segmentation at position: %s"
-                % str(img_parameter.channel_junction)
-            )
-            im_junction = img[:, :, img_parameter.channel_junction]
-            params_prep_img.channel_junction = 0
+        # check which channel is configured to use for cell segmentation:
+        channel_cell_segmentation = img_parameter.channel_junction
+        if self.params.channel_cell_segmentation != "":
+            try:
+                channel_cell_segmentation = img_parameter.__getattribute__(self.params.channel_cell_segmentation)
+            except AttributeError:
+                get_logger().error(
+                    "Channel %s does not exist! Wrong segmentation configuration!"
+                    % self.params.channel_cell_segmentation
+                )
 
-        if img_parameter.channel_nucleus >= 0:
+        # check which channel is configured to use for nuclei segmentation:
+        channel_nuclei_segmentation = img_parameter.channel_nucleus
+        if self.params.channel_nuclei_segmentation != "":
+            try:
+                channel_nuclei_segmentation = img_parameter.__getattribute__(self.params.channel_nuclei_segmentation)
+            except AttributeError:
+                get_logger().error(
+                    "Channel %s does not exist! Wrong segmentation configuration!"
+                    % self.params.channel_nuclei_segmentation
+                )
+
+        if channel_cell_segmentation >= 0:
             get_logger().info(
-                "Nucleus channel used for segmentation at position: %s"
-                % str(img_parameter.channel_nucleus)
+                "Channel that will be used for cell segmentation at position: %s"
+                % str(channel_cell_segmentation)
             )
-            im_nucleus = img[:, :, img_parameter.channel_nucleus]
-            params_prep_img.channel_nucleus = 1
+            im_junction = img[:, :, channel_cell_segmentation]
+            params_prep_img.channel_junction = 0  # might be called junction channel, but content depends on config
+
+        if channel_nuclei_segmentation >= 0:
+            get_logger().info(
+                "Channel that will be used for nucleus segmentation at position: %s"
+                % str(channel_nuclei_segmentation)
+            )
+            im_nucleus = img[:, :, channel_nuclei_segmentation]
+            params_prep_img.channel_nucleus = 1  # might be called nuclei channel, but content depends on config
 
         if im_nucleus is not None:
             return np.array([im_junction, im_nucleus]), params_prep_img

--- a/src/polarityjam/segmentation/cellpose.yml
+++ b/src/polarityjam/segmentation/cellpose.yml
@@ -1,5 +1,7 @@
 # SegmentationParameter
 path: cellpose.CellposeSegmenter
+channel_cell_segmentation: ""  # always uses the noted channel for segmentation of cells. leave empty for default.
+channel_nuclei_segmentation: ""  # always uses the noted channel for segmentation of nuclei. leave empty for default.
 manually_annotated_mask: "" # in case a manually annotated cellpose mask exists specify suffix here
 store_segmentation: False
 use_given_mask: True

--- a/src/polarityjam/segmentation/deepcell.yml
+++ b/src/polarityjam/segmentation/deepcell.yml
@@ -1,4 +1,6 @@
 path: deepcell.DeepCellSegmenter
+channel_cell_segmentation: ""  # always uses the noted channel for segmentation of cells. leave empty for default.
+channel_nuclei_segmentation: ""  # always uses the noted channel for segmentation of nuclei. leave empty for default.
 segmentation_mode: whole-cell # whole-cell or nuclear
 save_mask: False
 maxima_threshold: 0.18 # -1 for default values depending on segmentation_mode

--- a/src/polarityjam/segmentation/microsam.py
+++ b/src/polarityjam/segmentation/microsam.py
@@ -278,8 +278,7 @@ class MicrosamSegmenter:
 
         return masks
 
-    @staticmethod
-    def prepare(img, img_parameter):
+    def prepare(self, img, img_parameter):
         """Prepare the image for segmentation.
 
         Args:
@@ -304,35 +303,64 @@ class MicrosamSegmenter:
 
         numpy_img = np.zeros([img.shape[0], img.shape[1], 3])
 
-        if img_parameter.channel_junction < 0:
-            raise ValueError("No junction channel found.")
+        # check which channel is configured to use for cell segmentation:
+        channel_cell_segmentation = img_parameter.channel_junction
+        if self.params.channel_cell_segmentation != "":
+            try:
+                channel_cell_segmentation = img_parameter.__getattribute__(self.params.channel_cell_segmentation)
+            except AttributeError as e:
+                raise AttributeError("Channel %s does not exist! Wrong segmentation configuration!"
+                                     % self.params.channel_cell_segmentation) from e
+
+        # check which channel is configured to use for nuclei segmentation:
+        channel_nuclei_segmentation = img_parameter.channel_nucleus
+        if self.params.channel_nuclei_segmentation != "":
+            try:
+                channel_nuclei_segmentation = img_parameter.__getattribute__(self.params.channel_nuclei_segmentation)
+            except AttributeError as e:
+                raise AttributeError("Channel %s does not exist! Wrong segmentation configuration!"
+                                     % self.params.channel_nuclei_segmentation) from e
+
+        # check which channel is configured to use for organelle segmentation:
+        channel_organelle_segmentation = img_parameter.channel_organelle
+        if self.params.channel_organelle_segmentation != "":
+            try:
+                channel_organelle_segmentation = img_parameter.__getattribute__(
+                    self.params.channel_organelle_segmentation
+                )
+            except AttributeError as e:
+                raise AttributeError("Channel %s does not exist! Wrong segmentation configuration!"
+                                     % self.params.channel_organelle_segmentation) from e
+
+        if channel_cell_segmentation < 0:
+            raise ValueError("No channel for segmentation found.")
         else:
             get_logger().info(
-                "Junction channel used for segmentation at position: %s"
-                % str(img_parameter.channel_junction)
+                "Channel used for cell segmentation at position: %s"
+                % str(channel_cell_segmentation)
             )
-            im_junction = img[:, :, img_parameter.channel_junction]
-            params_prep_img.channel_junction = 0
+            im_junction = img[:, :, channel_cell_segmentation]
+            params_prep_img.channel_junction = 0  # might be called junction channel, but content depends on config
 
             numpy_img[:, :, 0] = im_junction
 
-        if img_parameter.channel_nucleus >= 0:
+        if channel_nuclei_segmentation >= 0:
             get_logger().info(
-                "Nucleus channel used for segmentation at position: %s"
-                % str(img_parameter.channel_nucleus)
+                "Channel used for nuclei segmentation at position: %s"
+                % str(channel_nuclei_segmentation)
             )
-            im_nucleus = img[:, :, img_parameter.channel_nucleus]
-            params_prep_img.channel_nucleus = 1
+            im_nucleus = img[:, :, channel_nuclei_segmentation]
+            params_prep_img.channel_nucleus = 1   # might be called nuclei channel, but content depends on config
 
             numpy_img[:, :, 1] = im_nucleus
 
-        if img_parameter.channel_organelle >= 0:
+        if channel_organelle_segmentation >= 0:
             get_logger().info(
-                "Organelle channel used for segmentation at position: %s"
-                % str(img_parameter.channel_organelle)
+                "Channel used for segmentation at position: %s"
+                % str(channel_organelle_segmentation)
             )
-            im_organelle = img[:, :, img_parameter.channel_organelle]
-            params_prep_img.channel_organelle = 2
+            im_organelle = img[:, :, channel_organelle_segmentation]
+            params_prep_img.channel_organelle = 2   # might be called organelle channel, but content depends on config
 
             numpy_img[:, :, 2] = im_organelle
 

--- a/src/polarityjam/segmentation/microsam.yml
+++ b/src/polarityjam/segmentation/microsam.yml
@@ -1,5 +1,8 @@
 # SegmentationParameter
 path: microsam.MicrosamSegmenter
+channel_cell_segmentation: ""  # always uses the noted channel for segmentation of cells. leave empty for default.
+channel_nuclei_segmentation: ""  # always uses the noted channel for segmentation of nuclei. leave empty for default.
+channel_organelle_segmentation: "" # always uses the noted channel for segmentation of organelle. empty for default.
 model_name: "vit_h"
 checkpoint_path: ""
 embedding_path: ""

--- a/src/polarityjam/segmentation/sam.py
+++ b/src/polarityjam/segmentation/sam.py
@@ -273,35 +273,65 @@ class SamSegmenter:
 
         numpy_img = np.zeros([img.shape[0], img.shape[1], 3])
 
-        if img_parameter.channel_junction < 0:
-            raise ValueError("No junction channel found.")
+        # check which channel is configured to use for cell segmentation:
+        channel_cell_segmentation = img_parameter.channel_junction
+        if self.params.channel_cell_segmentation != "":
+            try:
+                channel_cell_segmentation = img_parameter.__getattribute__(self.params.channel_cell_segmentation)
+            except AttributeError as e:
+                raise AttributeError("Channel %s does not exist! Wrong segmentation configuration!"
+                                     % self.params.channel_cell_segmentation) from e
+
+        # check which channel is configured to use for nuclei segmentation:
+        channel_nuclei_segmentation = img_parameter.channel_nucleus
+        if self.params.channel_nuclei_segmentation != "":
+            try:
+                channel_nuclei_segmentation = img_parameter.__getattribute__(self.params.channel_nuclei_segmentation)
+            except AttributeError as e:
+                raise AttributeError("Channel %s does not exist! Wrong segmentation configuration!"
+                                     % self.params.channel_nuclei_segmentation) from e
+
+        # check which channel is configured to use for organelle segmentation:
+        channel_organelle_segmentation = img_parameter.channel_organelle
+        if self.params.channel_organelle_segmentation != "":
+            try:
+                channel_organelle_segmentation = img_parameter.__getattribute__(
+                    self.params.channel_organelle_segmentation
+                )
+            except AttributeError as e:
+                raise AttributeError("Channel %s does not exist! Wrong segmentation configuration!"
+                                     % self.params.channel_organelle_segmentation) from e
+
+
+        if channel_cell_segmentation < 0:
+            raise ValueError("No channel for segmentation found.")
         else:
             get_logger().info(
-                "Junction channel used for segmentation at position: %s"
-                % str(img_parameter.channel_junction)
+                "Channel used for cell segmentation at position: %s"
+                % str(channel_cell_segmentation)
             )
-            im_junction = img[:, :, img_parameter.channel_junction]
-            params_prep_img.channel_junction = 0
+            im_junction = img[:, :, channel_cell_segmentation]
+            params_prep_img.channel_junction = 0  # might be called junction channel, but content depends on config
 
             numpy_img[:, :, 0] = im_junction
 
-        if img_parameter.channel_nucleus >= 0:
+        if channel_nuclei_segmentation>= 0:
             get_logger().info(
-                "Nucleus channel used for segmentation at position: %s"
-                % str(img_parameter.channel_nucleus)
+                "Channel used for nuclei segmentation at position: %s"
+                % str(channel_nuclei_segmentation)
             )
-            im_nucleus = img[:, :, img_parameter.channel_nucleus]
-            params_prep_img.channel_nucleus = 1
+            im_nucleus = img[:, :, channel_nuclei_segmentation]
+            params_prep_img.channel_nucleus = 1  # might be called nucleus channel, but content depends on config
 
             numpy_img[:, :, 1] = im_nucleus
 
-        if img_parameter.channel_organelle >= 0:
+        if channel_organelle_segmentation >= 0:
             get_logger().info(
-                "Organelle channel used for segmentation at position: %s"
-                % str(img_parameter.channel_organelle)
+                "Channel used for organelle segmentation at position: %s"
+                % str(channel_organelle_segmentation)
             )
-            im_organelle = img[:, :, img_parameter.channel_organelle]
-            params_prep_img.channel_organelle = 2
+            im_organelle = img[:, :, channel_organelle_segmentation]
+            params_prep_img.channel_organelle = 2  # might be called organelle channel, but content depends on config
 
             numpy_img[:, :, 2] = im_organelle
 

--- a/src/polarityjam/segmentation/sam.yml
+++ b/src/polarityjam/segmentation/sam.yml
@@ -1,5 +1,8 @@
 # SegmentationParameter
 path: sam.SamSegmenter
+channel_cell_segmentation: ""  # always uses the noted channel for segmentation of cells. leave empty for default.
+channel_nuclei_segmentation: ""  # always uses the noted channel for segmentation of nuclei. leave empty for default.
+channel_organelle_segmentation: "" # always uses the noted channel for segmentation of organelle. empty for default.
 model_url: "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth"
 # model_url: "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth"
 model_name: "sam_vit_h_4b8939.pth"


### PR DESCRIPTION
for all segmentation algorithms there is now the possibility to configure which channel should be used to do segmentation

e.g. for cells use channel "junction", for nuclei use channel "nuclei"

so in theory it is possible to do a segmentation with the marker channel by configuring that.

closes #64 
