### PR TITLE
fix normalizing FOI plot by user specified length unit

### DIFF
--- a/src/polarityjam/controller/plotter.py
+++ b/src/polarityjam/controller/plotter.py
@@ -2288,6 +2288,10 @@ class Plotter:
         ).feature_of_interest
         foi = single_cell_dataset[foi_name]
 
+        # normalize for length_unit (e.g. microns)
+        if self.params.length_unit == "microns":
+            foi = foi / pixel_to_micron_ratio
+
         # figure and axes
         fig, ax = self._get_figure(1)
         ax.imshow(im_junction.data, cmap=plt.cm.gray, alpha=1.0)

--- a/src/polarityjam/controller/plotter.py
+++ b/src/polarityjam/controller/plotter.py
@@ -2290,7 +2290,7 @@ class Plotter:
 
         # normalize for length_unit (e.g. microns)
         if self.params.length_unit == "microns":
-            foi = foi / pixel_to_micron_ratio
+            foi = foi * pixel_to_micron_ratio
 
         # figure and axes
         fig, ax = self._get_figure(1)

--- a/src/polarityjam/model/parameter.py
+++ b/src/polarityjam/model/parameter.py
@@ -207,6 +207,7 @@ class PlotParameter(Parameter):
 
         self.outline_width = None
         self.length_scalebar_microns = None
+        self.length_unit = None
 
         self.graphics_output_format = None
         self.dpi = None


### PR DESCRIPTION
the `length_unit` paramter of the plot was ignored when setting to "microns". Now setting this parameter to "microns" has the effect that the Feature of Interest values are additionally normalized by the pixel-to-micron value set by the user (as Image-parameter).